### PR TITLE
CSCIDA-658: Fixed CSS issue with exception dialog

### DIFF
--- a/nextcloud/core/templates/exception.php
+++ b/nextcloud/core/templates/exception.php
@@ -4,7 +4,7 @@
 
 style('core', ['styles', 'header']);
 ?>
-<div class="error error-wide">
+<div class="error">
 	<h2><?php p($l->t('Internal Server Error')) ?></h2>
 	<p><?php p($l->t('The server was unable to complete your request.')) ?></p>
 	<p><?php p($l->t('If this happens again, please send the technical details below to the server administrator.')) ?></p>


### PR DESCRIPTION
In the case that there is an exception shown in the frontpage where the login screen is, previously it was misaligned to be out of the screen. Now that error-wide css definition is removed and the error will be displayed within the parent container.